### PR TITLE
Upgrade to 1.0.0-alpha01 and AS 4.2 Canary 8

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
     defaultConfig {
         applicationId "com.example.android11latamcompose"
         minSdkVersion 29
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
 
     ext {
-        compose_version = '0.1.0-dev17'
+        compose_version = '1.0.0-alpha01'
         kotlin_version = "1.4.0"
     }
 
@@ -14,7 +14,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.0-alpha07"
+        classpath 'com.android.tools.build:gradle:4.2.0-alpha08'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.6-rc-6-bin.zip


### PR DESCRIPTION
Upgrading dependencies to support Compose `1.0.0-alpha01`. Now it works with Android Studio 4.2 Canary 8 and `@Preview` annotation works properly.